### PR TITLE
Add basic golang skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore the compserv binary
+compserv
+
 # Terraform
 terraform/.terraform*
 terraform/terraform.*

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rhmdnd/compserv
+
+go 1.16

--- a/main.go
+++ b/main.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {
+}


### PR DESCRIPTION
Layout the main.go file, initialize go mod, and ignore the build binary.
Future patches will expand on this to start including a protocol buffer
definition for the API.