### PR TITLE
Add a make file and target for building binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+build:
+	mkdir -p builds/
+	go build -o builds/ cmd/compserv-server.go

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Sanitizing the compliance data and using a relational database will better
 enable this at scale, as opposed to loading compliance reports for each cluster
 from object storage.
 
+## Building
+
+You can use the `Makefile` target to build go binaries, which are output to
+`builds/` by default:
+
+```console
+$ make build
+```
+
 ## Deploying
 
 You can deploy the database using [terraform](https://www.terraform.io/).


### PR DESCRIPTION
Let's add a build target for creating builds so it's easy to invoke and
consistent as the project grows.

Fixes #9