### PR TITLE
Remove the main.go file

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,0 @@
-package main
-
-func main() {
-}


### PR DESCRIPTION
We don't need this since we're putting the main entrypoint for the
service in the cmd/ directory. Let's remove this since it's not
necessary and just produces and empty binary when you build from the
root of the repository.