### PR TITLE
Add test for db migrations

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,32 @@
+name: PostgreSQL Migration CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+env:
+  GO_VERSION: '1.18'
+  DB_USER: dbadmin
+  DB_PASSWORD: secret
+  DB_NAME: compliance
+  DB_HOST: localhost
+  # podman does exist on Ubuntu, but it's old and seems buggy
+  RUNTIME: docker
+jobs:
+  test:
+    name: migrate-test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Install golang-migrate
+      run: |
+        mkdir -p ${GITHUB_WORKSPACE}/tools
+        echo "${GITHUB_WORKSPACE}/tools" >> ${GITHUB_PATH}
+        make tools/migrate
+
+    - name: Run migrations
+      run: |
+        bash -x ./migrations/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Ignore builds
+# Ignore builds and tools
 builds/
+tools/
 
 # Ignore potential configs
 configs/config.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,28 @@
-build:
-	mkdir -p builds/
-	go build -o builds/ cmd/compserv-server.go
+OS := $(shell go env GOOS)
+ARCH := $(shell go env GOARCH)
 
+MIGRATE_VERSION := v4.15.2
+
+BUILDS_DIR := builds
+TOOLS_DIR := tools
+
+.PHONY: $(BUILDS_DIR)
+$(BUILDS_DIR):
+	mkdir -p $(BUILDS_DIR)
+
+.PHONY: $(TOOLS_DIR)
+$(TOOLS_DIR):
+	mkdir -p $(TOOLS_DIR)
+
+.PHONY: build
+build: $(BUILDS_DIR)
+	go build -o $(BUILDS_DIR) cmd/compserv-server.go
+
+.PHONY: test
 test:
 	go test -v ./...
+
+.PHONY: $(TOOLS_DIR)/migrate
+$(TOOLS_DIR)/migrate: $(TOOLS_DIR)
+	curl -sSL https://github.com/golang-migrate/migrate/releases/download/$(MIGRATE_VERSION)/migrate.$(OS)-$(ARCH).tar.gz | tar xz migrate -O > $(TOOLS_DIR)/migrate
+	chmod u+x $@

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -30,3 +30,16 @@ Apply all down migrations:
 ```console
 $ ./migrate -database $POSTGRESQL_URL -path migrations down
 ```
+
+## Test
+
+To run a quick and easy test of the migrations, use the `test.sh` script:
+```console
+bash migrations/test.sh
+```
+
+If you don't have the `migrate` CLI tool installed in your `$PATH`, run:
+```console
+make tools/migrate
+PATH=$PATH:$(pwd)/tools bash migrations/test.sh
+```

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -6,7 +6,8 @@ This folder contains database migrations for the compliance service using
 This project requires using the `migrate` CLI to change the database schema and
 to add new migrations. Please refer to the
 [documentation](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate)
-for installation instructions.
+for installation instructions or simply run `make tools/migrate` from the root of
+this project.
 
 ## Examples
 

--- a/migrations/test.sh
+++ b/migrations/test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+if [ -z $RUNTIME ]; then
+    if which podman 1>/dev/null 2>&1; then
+        RUNTIME=podman
+    else
+        RUNTIME=docker
+    fi
+fi
+
+DB_USER=${DB_USER:-"dbadmin"}
+DB_PASSWORD=${DB_PASSWORD:-"secret"}
+DB_NAME=${DB_NAME:-"compliance"}
+DB_HOST=${DB_HOST:-"localhost"}
+
+trap cleanup EXIT
+
+function cleanup {
+    $RUNTIME stop postgres
+    $RUNTIME rm postgres
+}
+
+function wait_for_db_init {
+    health_status=""
+
+    for i in $(seq 1 30); do
+        if [ $RUNTIME == "podman" ]; then
+            healthcheck_str="{{if .State.Healthcheck}}{{print .State.Healthcheck.Status}}{{end}}"
+        else
+            healthcheck_str="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}"
+        fi
+
+        health_status=$($RUNTIME inspect --format="$healthcheck_str" postgres)
+        if [ "$health_status" == "healthy" ] ; then
+            break
+        fi
+        sleep 3
+    done
+
+    if [ $health_status != "healthy" ] ; then
+        echo "Failed to wait for pgsql container to come up"
+        exit 1
+    fi
+}
+
+$RUNTIME run -d --name postgres \
+    -e POSTGRES_USER=$DB_USER \
+    -e POSTGRES_DB=$DB_NAME \
+    -e POSTGRES_PASSWORD=$DB_PASSWORD \
+    -p 5432:5432 \
+    --health-cmd pg_isready \
+    --health-interval 10s \
+    --health-timeout 5s \
+    --health-retries 5 \
+    postgres:latest
+
+wait_for_db_init
+
+POSTGRESQL_URL="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:5432/$DB_NAME?sslmode=disable"
+
+migrate -database $POSTGRESQL_URL -path migrations up
+echo "y" | migrate -database $POSTGRESQL_URL -path migrations down


### PR DESCRIPTION
- make: Add a target to download the migrate binary

Adds a `make migrate` target for the Makefile that fetches
the migrate CLI. Adds several top-level Makefile variables for
autodetection of the OS and the arch so that we support different OS-es
and arches from the start.

- tests: Add a GH action test for the DB migrations

Adds a github action that spawns a postgres container and runs migrate
up and migrate down to exercise our database migrations.