### PR TITLE
Add an OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- rhmdnd
+- jhrozek
+- mrogers950
+- vincent056
+reviewers:
+- rhmdnd
+- jhrozek
+- mrogers950
+- vincent056


### PR DESCRIPTION
We need an OWNERS file to integrate OpenShift CI into the project. Let's
add one now with a base set of approvers and reviewers who are also
reponsible for the ComplianceAsCode/compliance-operator.