### PR TITLE
Add basic kustomize support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ $ make build
 
 ## Deploying
 
+### AWS
+
 You can deploy the database using [terraform](https://www.terraform.io/).
 
 ```console
@@ -61,6 +63,19 @@ $ terraform apply
 ```
 
 Cleanup the resources using `terraform destroy`.
+
+### Kubernetes
+
+Alternatively, you can deploy the database to a Kubernetes cluster with
+[Kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization).
+This functionality is primarily for development purposes and requires
+additional work to intergate with the compliance service. In the future, we may
+consider breaking the current Kustomize structure into overlays for different
+environments.
+
+```console
+$ kubectl apply -k kustomize
+```
 
 ## Migrations
 

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  selector:
+    matchLabels:
+      app: postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - image: postgres:13-alpine
+        name: postgres
+        env:
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgres-secret
+                key: password
+        ports:
+          - containerPort: 5432
+            name: postgres
+        volumeMounts:
+          - name: postgres-persistent-storage
+            mountPath: /var/lib/postgres
+      volumes:
+        - name: postgres-persistent-storage
+          emptyDir: {}

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+  - secret.yaml
+

--- a/kustomize/secret.yaml
+++ b/kustomize/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+data:
+  password: cGFzc3dvcmQK

--- a/kustomize/service.yaml
+++ b/kustomize/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: postgres


### PR DESCRIPTION
This commit adds basic plumbing to use kustomize to deploy a postgres
database on a kubernetes deployment. This will expand to include the
actual compliance service application. For now, it's focused solely on
the database so it can be used for development purposes.

Related to #22