### PR TITLE
Add config-file flag

### DIFF
--- a/cmd/compserv-server.go
+++ b/cmd/compserv-server.go
@@ -14,8 +14,9 @@ import (
 
 func main() {
 	var configDir = flag.String("config-dir", "configs/", "Path to YAML configuration directory containing a config.yaml file.")
+	var configFile = flag.String("config-file", "config.yaml", "File name of the service config")
 	flag.Parse()
-	c := config.ParseConfig(*configDir)
+	c := config.ParseConfig(*configDir, *configFile)
 	connStr := config.GetDatabaseConnectionString(c)
 	db, err := gorm.Open(postgres.Open(connStr), &gorm.Config{})
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -12,13 +13,18 @@ import (
 	"github.com/spf13/viper"
 )
 
-func ParseConfig(configDir string) map[string]string {
+func ParseConfig(configDir, configFile string) map[string]string {
 	viper.SetDefault("app.host", "localhost")
 	viper.SetDefault("app.port", "50051")
 	viper.SetDefault("database.port", "5432")
 	viper.SetDefault("database.name", "compliance")
-	viper.SetConfigName("config")
-	viper.SetConfigType("yaml")
+	configType := "yaml"
+	parts := strings.Split(configFile, ".")
+	if ln := len(parts); ln > 1 {
+		configType = parts[ln-1]
+	}
+	viper.SetConfigName(configFile)
+	viper.SetConfigType(configType)
 	viper.AddConfigPath(configDir)
 	err := viper.ReadInConfig()
 	if err != nil {


### PR DESCRIPTION
This lets you specify the config file location along with -config-dir. It also
determines the config type from the given file extension.

  $ ./builds/compserv-server -config-file sample-config.yaml