### PR TITLE
Add test-migrate Makefile target

### DIFF
--- a/migrations/test.sh
+++ b/migrations/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ -z $MIGRATE ]; then
+    MIGRATE=migrate
+fi
+
 if [ -z $RUNTIME ]; then
     if which podman 1>/dev/null 2>&1; then
         RUNTIME=podman
@@ -58,5 +62,5 @@ wait_for_db_init
 
 POSTGRESQL_URL="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:5432/$DB_NAME?sslmode=disable"
 
-migrate -database $POSTGRESQL_URL -path migrations up
-echo "y" | migrate -database $POSTGRESQL_URL -path migrations down
+$MIGRATE -database $POSTGRESQL_URL -path migrations up
+echo "y" | $MIGRATE -database $POSTGRESQL_URL -path migrations down


### PR DESCRIPTION
- Also make the download of migrate conditional; If `MIGRATE=` is set in the
  environment for `make` it will use that, otherwise it will look in PATH. If
  neither are available it will download migrate locally into tools/.