### PR TITLE
Add golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,3 +24,18 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        # differnt version on purpose until golangci-lint gains support for 1.18
+        go-version: 1.17
+
+    - name: Verify
+      run: make verify

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+---
+run:
+  concurrency: 6
+  timeout: 5m
+linters:
+  enable-all: true
+  disable:
+    - cyclop
+    - exhaustivestruct
+    - exhaustruct
+    - forbidigo
+    - funlen
+    - godot
+    - nlreturn
+    - varnamelen
+    - wsl

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)
 
 MIGRATE_VERSION := v4.15.2
+GOLANGCI_LINT_VERSION := v1.46.2
 
 BUILDS_DIR := builds
 TOOLS_DIR := tools
@@ -27,7 +28,14 @@ test:
 test-migrate: $(TOOLS_DIR)/migrate
 	MIGRATE=$(MIGRATE) migrations/test.sh
 
-.PHONY: $(TOOLS_DIR)/migrate
+.PHONY: verify
+verify: verify-go-lint
+
+.PHONY: verify-go-lint
+verify-go-lint: $(TOOLS_DIR)/golangci-lint ## Verify the golang code by linting
+	# we use go 1.17 because golangci-lint still has issues with 1.18
+	GL_DEBUG=gocritic $(TOOLS_DIR)/golangci-lint --go 1.17 run
+
 MIGRATE = ./$(TOOLS_DIR)/migrate
 $(TOOLS_DIR)/migrate: $(TOOLS_DIR) ## Download migrate locally if necessary.
 ifeq (,$(wildcard $(MIGRATE)))
@@ -41,3 +49,12 @@ else
 MIGRATE = $(shell which migrate)
 endif
 endif
+
+$(TOOLS_DIR)/golangci-lint:
+	export \
+		VERSION=$(GOLANGCI_LINT_VERSION) \
+		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
+		BINDIR=$(TOOLS_DIR) && \
+	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
+	$(TOOLS_DIR)/golangci-lint version
+	$(TOOLS_DIR)/golangci-lint linters

--- a/cmd/compserv-server.go
+++ b/cmd/compserv-server.go
@@ -13,8 +13,10 @@ import (
 )
 
 func main() {
-	var configDir = flag.String("config-dir", "configs/", "Path to YAML configuration directory containing a config.yaml file.")
-	var configFile = flag.String("config-file", "config.yaml", "File name of the service config")
+	configDir := flag.String("config-dir", "configs/",
+		"Path to YAML configuration directory containing a config.yaml file.")
+	configFile := flag.String("config-file", "config.yaml",
+		"File name of the service config")
 	flag.Parse()
 	c := config.ParseConfig(*configDir, *configFile)
 	connStr := config.GetDatabaseConnectionString(c)
@@ -35,5 +37,7 @@ func main() {
 	grpcServer := grpc.NewServer(opts...)
 	api.RegisterComplianceServiceServer(grpcServer, api.NewServer(db))
 	log.Printf("Server listening on %s", appStr)
-	grpcServer.Serve(lis)
+	if err := grpcServer.Serve(lis); err != nil {
+		log.Fatalf("Failed to start grpc server %v", err)
+	}
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -7,6 +7,6 @@ type server struct {
 	database *gorm.DB
 }
 
-func NewServer(db *gorm.DB) *server {
+func NewServer(db *gorm.DB) *server { // nolint:revive,golint // returning a private struct from an exported fn is fine
 	return &server{database: db}
 }


### PR DESCRIPTION
- make: Add a Makefile target that runs golangci-lint

Adds a new make target 'make verify' that is meant to run all the linters and code checks we'll have. For now, there's a single dependency `make verify-go-lint` that runs the golangci-lint linter.

- Fix linter errors reported by golangci-lint

Please see its commit message for all the fixes

- Add a github action to run the linter on every commit

what the title says
