### PR TITLE
Add a makefile target for `deploy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,7 @@ $(TOOLS_DIR)/golangci-lint:
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
 	$(TOOLS_DIR)/golangci-lint version
 	$(TOOLS_DIR)/golangci-lint linters
+
+.PHONY: deploy
+deploy:
+	kubectl apply -k kustomize

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ environments.
 $ kubectl apply -k kustomize
 ```
 
+Alternatively, you can use the `deploy` Makefile target to deploy the
+compliance service and a PostgreSQL database into a Kubernetes cluster.
+
+```console
+$ make deploy
+```
+
 ## Migrations
 
 Please refer to the [migrations documentation](./migrations/README.md) for


### PR DESCRIPTION
Add the ability to deploy the compliance service using kustomize and an
existing Kubernetes cluster.

Additionally patches will add more functionality to kustomize to support
deploying the actual compliance service. This patch will be referenced
in the openshift/release configuration to ensure kustomize is used to
deploy the application in CI.

Fixes #43 