### PR TITLE
Add a namespace for the service to kustomize

### DIFF
--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,4 +1,6 @@
+namespace: compserv
 resources:
+  - namespace.yaml
   - deployment.yaml
   - service.yaml
   - secret.yaml

--- a/kustomize/namespace.yaml
+++ b/kustomize/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: compserv


### PR DESCRIPTION
While running `kubectl apply -k kustomize` will put the resources in the
default namespace, this apparently isn't possible in CI. The e2e-aws CI
fails with an error similar to the following:

  ./tools/kubectl apply -k kustomize
  Error from server (NotFound): error when creating "kustomize": namespaces "ci-op-lct9f0l5" not found

Instead of relying on a namespace, we can be explicit by specifying the
namespace we want to deploy resources to.

This commit updates the kustomize files to create a namespace and use
that namespace for resources.