### PR TITLE
Refactor useful functions from test.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ verify: verify-go-lint
 # linter, but ignore anything in vendor/.
 .PHONY: bash-lint
 bash-lint:
-	shellcheck $(shell find . -type f -name '*.sh' -not -path "./vendor/*")
+	shellcheck -x $(shell find . -type f -name '*.sh' -not -path "./vendor/*")
 
 .PHONY: verify-go-lint
 verify-go-lint: $(TOOLS_DIR)/golangci-lint ## Verify the golang code by linting

--- a/migrations/test.sh
+++ b/migrations/test.sh
@@ -1,63 +1,18 @@
 #!/bin/bash
 
+MIGRATIONS_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)
+TOP_DIR=$(dirname "$MIGRATIONS_DIR")
+# shellcheck source=utils/functions.sh
+source "${TOP_DIR}/utils/functions.sh"
+
 if [ -z "$MIGRATE" ]; then
     MIGRATE=migrate
 fi
 
-if [ -z "$RUNTIME" ]; then
-    if command -v podman 1>/dev/null 2>&1; then
-        RUNTIME=podman
-    else
-        RUNTIME=docker
-    fi
-fi
-
-DB_USER=${DB_USER:-"dbadmin"}
-DB_PASSWORD=${DB_PASSWORD:-"secret"}
-DB_NAME=${DB_NAME:-"compliance"}
-DB_HOST=${DB_HOST:-"localhost"}
-
-trap cleanup EXIT
-
-function cleanup {
-    $RUNTIME stop postgres
-    $RUNTIME rm postgres
-}
-
-function wait_for_db_init {
-    health_status=""
-
-    for _ in $(seq 1 30); do
-        if [ $RUNTIME == "podman" ]; then
-            healthcheck_str="{{if .State.Healthcheck}}{{print .State.Healthcheck.Status}}{{end}}"
-        else
-            healthcheck_str="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}"
-        fi
-
-        health_status=$($RUNTIME inspect --format="$healthcheck_str" postgres)
-        if [ "$health_status" == "healthy" ] ; then
-            break
-        fi
-        sleep 3
-    done
-
-    if [ "$health_status" != "healthy" ] ; then
-        echo "Failed to wait for pgsql container to come up"
-        exit 1
-    fi
-}
-
-$RUNTIME run -d --name postgres \
-    -e POSTGRES_USER="$DB_USER" \
-    -e POSTGRES_DB="$DB_NAME" \
-    -e POSTGRES_PASSWORD="$DB_PASSWORD" \
-    -p 5432:5432 \
-    --health-cmd pg_isready \
-    --health-interval 10s \
-    --health-timeout 5s \
-    --health-retries 5 \
-    postgres:latest
-
+set_container_runtime
+set_database_environment_variables
+trap cleanup_database_container EXIT
+create_database_container
 wait_for_db_init
 
 POSTGRESQL_URL="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:5432/$DB_NAME?sslmode=disable"

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# A common set of bash function that are useful for setting up and tearing down
+# test infrastructure.
+
+function set_container_runtime {
+    if [ -z "$RUNTIME" ]; then
+        if command -v podman 1>/dev/null 2>&1; then
+            RUNTIME=podman
+        else
+            RUNTIME=docker
+        fi
+    fi
+}
+
+function set_database_environment_variables {
+    DB_USER=${DB_USER:-"dbadmin"}
+    DB_PASSWORD=${DB_PASSWORD:-"secret"}
+    DB_NAME=${DB_NAME:-"compliance"}
+    DB_HOST=${DB_HOST:-"localhost"}
+}
+
+function cleanup_database_container {
+    $RUNTIME stop postgres
+    $RUNTIME rm postgres
+}
+
+function create_database_container {
+    $RUNTIME run -d --name postgres \
+        -e POSTGRES_USER="$DB_USER" \
+        -e POSTGRES_DB="$DB_NAME" \
+        -e POSTGRES_PASSWORD="$DB_PASSWORD" \
+        -p 5432:5432 \
+        --health-cmd pg_isready \
+        --health-interval 10s \
+        --health-timeout 5s \
+        --health-retries 5 \
+        postgres:latest
+}
+
+function wait_for_db_init {
+    health_status=""
+
+    for _ in $(seq 1 30); do
+        if [ $RUNTIME == "podman" ]; then
+            healthcheck_str="{{if .State.Healthcheck}}{{print .State.Healthcheck.Status}}{{end}}"
+        else
+            healthcheck_str="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}"
+        fi
+
+        health_status=$($RUNTIME inspect --format="$healthcheck_str" postgres)
+        if [ "$health_status" == "healthy" ] ; then
+            break
+        fi
+        sleep 3
+    done
+
+    if [ "$health_status" != "healthy" ] ; then
+        echo "Failed to wait for pgsql container to come up"
+        exit 1
+    fi
+}


### PR DESCRIPTION
The test.sh script we use to test database migrations contains useful
commands that we can re-use in other tests.

This commit pulls those useful bits into a common file under utils/ and
sources them from test.sh. Future patches will use these functions for
testing the database layer directly against a PostgreSQL container.