### PR TITLE
Don't ignore migrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,5 @@ configs/config.yaml
 terraform/.terraform*
 terraform/terraform.*
 
-# Ignore the golang-migrate/migrate binary
-migrate
-
 *.swp
 .idea


### PR DESCRIPTION
Initially, we were using a migrate binary in the root of the project
repository. Since then we've moved it to a tools/ directory with similar
utilities and we just ignore that.

By ignoring migrate, we potentially match any dependency names in vendor
(like golang-migrate/migrate).

Let's remove this so we can actually use migrate.

Fixes #72