### PR TITLE
Use dependabot to keep our deps up2date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+    - "ok-to-test"


### PR DESCRIPTION
Let's use dependabot:
    https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/
    https://help.github.com/en/github/administering-a-repository/about-github-dependabot
to keep our dependencies up-to-date and avoid CVEs in our code.

Dependabot would try to add the `/ok-to-test` label so that our CI runs
automatically.
