### PR TITLE
Use db instead of conn for database variable

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -21,7 +21,7 @@ func getDatabaseConnection(t *testing.T) *sql.DB {
 	// database to run tests.
 	connStr := "host=localhost user=dbadmin dbname=compliance password=secret port=5432 sslmode=disable"
 
-	conn, err := sql.Open("postgres", connStr)
+	db, err := sql.Open("postgres", connStr)
 	if err != nil {
 		msg := fmt.Sprintf("Unable to initialize connection to test database: %s", err)
 		t.Skip(msg)
@@ -32,7 +32,7 @@ func getDatabaseConnection(t *testing.T) *sql.DB {
 	// database connection directly
 	// (https://github.com/golang/go/issues/48309).
 	for i := 0; i < 10; i++ {
-		if err := conn.Ping(); err != nil {
+		if err := db.Ping(); err != nil {
 			// We should only retry if we're dealing with a network
 			// issue of some kind. No amount of retries is going to
 			// fix incorrect credentials.
@@ -48,14 +48,14 @@ func getDatabaseConnection(t *testing.T) *sql.DB {
 		}
 	}
 
-	return conn
+	return db
 }
 
 func getMigrationHelper(t *testing.T) *migrate.Migrate {
 	t.Helper()
-	conn := getDatabaseConnection(t)
+	db := getDatabaseConnection(t)
 
-	driver, err := postgres.WithInstance(conn, &postgres.Config{})
+	driver, err := postgres.WithInstance(db, &postgres.Config{})
 	if err != nil {
 		t.Skip("Unable to initialize database driver for migrations")
 	}


### PR DESCRIPTION
The sql module has a type for databases (DB) and a type for connections
(Conn). We referred to the database, which is returned by sql.Open(), as
a connection, but it's really of type DB.

For test writers this can be confusing if they think they're dealing
with a Conn type instead of a DB.

Let's update the variable name to more accurately reflect what
sql.Open() returns.