### PR TITLE
Implement a foreign key for subjects

### DIFF
--- a/migrations/000003_add_subject_parent_id.down.sql
+++ b/migrations/000003_add_subject_parent_id.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE subjects DROP CONSTRAINT fk_subjects_parent_id;
+
+ALTER TABLE subjects DROP COLUMN parent_id;

--- a/migrations/000003_add_subject_parent_id.up.sql
+++ b/migrations/000003_add_subject_parent_id.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE subjects
+ADD COLUMN parent_id UUID;
+
+ALTER TABLE subjects
+ADD CONSTRAINT fk_subjects_parent_id FOREIGN KEY (parent_id) REFERENCES subjects (id);

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -25,9 +25,10 @@ type Metadata struct {
 }
 
 type Subject struct {
-	ID   string
-	Name string
-	Type string
+	ID       string
+	Name     string
+	Type     string
+	ParentID sql.NullString
 }
 
 func getDatabaseConnection(t *testing.T) *sql.DB {


### PR DESCRIPTION
We want to be able to nest subjects and build a hierarchical
relationship between them. This commit does that by adding a database
migration that adds a new column for parent_id and adds a FK
relationship to it.

This approach was discussed in https://github.com/rhmdnd/compserv/issues/84