### PR TITLE
Restructure test packaging

### DIFF
--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -1,4 +1,4 @@
-package integration_test // nolint:typecheck
+package tests
 
 type Subject struct {
 	ID   string

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,4 +1,4 @@
-package integration_test // nolint:typecheck
+package tests // nolint:testpackage
 
 import (
 	"database/sql"
@@ -72,7 +72,7 @@ func getMigrationHelper(t *testing.T) *migrate.Migrate {
 	if err != nil {
 		t.Skip("Unable to initialize database driver for migrations")
 	}
-	m, err := migrate.NewWithDatabaseInstance("file://../../migrations", "postgres", driver)
+	m, err := migrate.NewWithDatabaseInstance("file://../migrations", "postgres", driver)
 	if err != nil {
 		t.Skip("Unable to initialize migrations")
 	}


### PR DESCRIPTION
Before, we nested the integration tests in tests/integration and the
package name was integration_test. This caused some linting issues where
the linter expected the package name to be integration (presumably
because of the directory name).

This commit address two different linting issues by removing a noop
linting check and disabling testpackage linting on the integration test
package line. Without disabling linting in this case, the linter expects
to have the package name be `integration_test_test`. Renaming the file
to `integration` won't run any tests since golang expects to run tests
against files ending in _test.go.

This commit also takes the opportunity to remove a layer in the tests
directory. For now, we can keep the structure simple and add more layers
when we actually need them.

Fixes #101