### PR TITLE
Cleanup usage of Skip in integration tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -30,8 +29,7 @@ func getDatabaseConnection(t *testing.T) *sql.DB {
 
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
-		msg := fmt.Sprintf("Unable to initialize connection to test database: %s", err)
-		t.Skip(msg)
+		t.Skipf("Unable to initialize connection to test database: %s", err)
 	}
 
 	// Wait up to 30 seconds to establish a connection with the database.
@@ -56,8 +54,7 @@ func getDatabaseConnection(t *testing.T) *sql.DB {
 				time.Sleep(duration)
 				continue
 			} else {
-				msg := fmt.Sprintf("Unable to establish connection to test database: %s", err)
-				t.Skip(msg)
+				t.Skipf("Unable to establish connection to test database: %s", err)
 			}
 		}
 	}
@@ -71,11 +68,11 @@ func getMigrationHelper(t *testing.T) *migrate.Migrate {
 
 	driver, err := postgres.WithInstance(db, &postgres.Config{})
 	if err != nil {
-		t.Skip("Unable to initialize database driver for migrations")
+		t.Skipf("Unable to initialize database driver for migrations: %s", err)
 	}
 	m, err := migrate.NewWithDatabaseInstance("file://../migrations", "postgres", driver)
 	if err != nil {
-		t.Skip("Unable to initialize migrations")
+		t.Skipf("Unable to initialize migrations: %s", err)
 	}
 	return m
 }


### PR DESCRIPTION
Previously, we were using fmt.Sprintf to create strings with error
messages and then passing that to t.Skip(msg). The testing module
supports t.Skipf(), which handles formatting. Let's use that instead.

This commit also adds relevant error messages to logs by incorporating
them with pre-existing error messages using Skipf().