### PR TITLE
Organize integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/aws/aws-sdk-go v1.44.59
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/google/uuid v1.3.0
-	github.com/lib/pq v1.10.6
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
 	google.golang.org/grpc v1.48.0
@@ -33,6 +32,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.4 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/lib/pq v1.10.6 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect

--- a/tests/constants.go
+++ b/tests/constants.go
@@ -1,0 +1,3 @@
+package tests
+
+const clusterName = "cluster.example.com"

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -1,7 +1,0 @@
-package tests
-
-type Subject struct {
-	ID   string
-	Name string
-	Type string
-}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,94 +1,12 @@
 package tests // nolint:testpackage
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
-	"net"
 	"strings"
 	"testing"
-	"time"
 
-	migrate "github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file" // Necessary to invoke migrations locally in the repository
-	"github.com/google/uuid"
-	_ "github.com/lib/pq" // Necessary to use the PostgreSQL database driver and connecting to a PostgreSQL database
 	"github.com/stretchr/testify/assert"
-	gorm_postgres "gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
-
-const clusterName = "cluster.example.com"
-
-func getDatabaseConnection(t *testing.T) *sql.DB {
-	t.Helper()
-	// Generlize this so that it can be used to connect to any Postgres
-	// database to run tests.
-	connStr := "host=localhost user=dbadmin dbname=compliance password=secret port=5432 sslmode=disable"
-
-	db, err := sql.Open("postgres", connStr)
-	if err != nil {
-		msg := fmt.Sprintf("Unable to initialize connection to test database: %s", err)
-		t.Skip(msg)
-	}
-
-	// Wait up to 30 seconds to establish a connection with the database.
-	// Remove this logic when we have the ability to set retries in the
-	// database connection directly
-	// (https://github.com/golang/go/issues/48309).
-	for i := 0; i < 10; i++ {
-		if err := db.Ping(); err != nil {
-			// We should only retry if we're dealing with a network
-			// issue of some kind. No amount of retries is going to
-			// fix incorrect credentials.
-			var netError *net.OpError
-			if errors.As(err, &netError) {
-				t.Logf("Retrying database connection due to error: %s", err)
-				// Linting says we shouldn't use the following:
-				// time.Sleep(3 * time.Second)
-				// but we can't use
-				// duration := 3
-				// time.Sleep(duration * time.Second)
-				// which causes a type mismatch.
-				duration, _ := time.ParseDuration("0m3s")
-				time.Sleep(duration)
-				continue
-			} else {
-				msg := fmt.Sprintf("Unable to establish connection to test database: %s", err)
-				t.Skip(msg)
-			}
-		}
-	}
-
-	return db
-}
-
-func getMigrationHelper(t *testing.T) *migrate.Migrate {
-	t.Helper()
-	db := getDatabaseConnection(t)
-
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	if err != nil {
-		t.Skip("Unable to initialize database driver for migrations")
-	}
-	m, err := migrate.NewWithDatabaseInstance("file://../migrations", "postgres", driver)
-	if err != nil {
-		t.Skip("Unable to initialize migrations")
-	}
-	return m
-}
-
-func getGormHelper() *gorm.DB {
-	connStr := "host=localhost user=dbadmin dbname=compliance password=secret port=5432 sslmode=disable"
-	gormDB, _ := gorm.Open(gorm_postgres.Open(connStr), &gorm.Config{})
-	return gormDB
-}
-
-func getUUIDString() string {
-	value, _ := uuid.NewRandom()
-	return value.String()
-}
 
 // Each test assumes the database is unmanaged. The test is responsible for
 // setting up the state it requires for its test logic. This keeps the

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,0 +1,92 @@
+package tests
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file" // Necessary to invoke migrations locally in the repository
+	"github.com/google/uuid"
+	gorm_postgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type Subject struct {
+	ID   string
+	Name string
+	Type string
+}
+
+func getDatabaseConnection(t *testing.T) *sql.DB {
+	t.Helper()
+	// Generlize this so that it can be used to connect to any Postgres
+	// database to run tests.
+	connStr := "host=localhost user=dbadmin dbname=compliance password=secret port=5432 sslmode=disable"
+
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		msg := fmt.Sprintf("Unable to initialize connection to test database: %s", err)
+		t.Skip(msg)
+	}
+
+	// Wait up to 30 seconds to establish a connection with the database.
+	// Remove this logic when we have the ability to set retries in the
+	// database connection directly
+	// (https://github.com/golang/go/issues/48309).
+	for i := 0; i < 10; i++ {
+		if err := db.Ping(); err != nil {
+			// We should only retry if we're dealing with a network
+			// issue of some kind. No amount of retries is going to
+			// fix incorrect credentials.
+			var netError *net.OpError
+			if errors.As(err, &netError) {
+				t.Logf("Retrying database connection due to error: %s", err)
+				// Linting says we shouldn't use the following:
+				// time.Sleep(3 * time.Second)
+				// but we can't use
+				// duration := 3
+				// time.Sleep(duration * time.Second)
+				// which causes a type mismatch.
+				duration, _ := time.ParseDuration("0m3s")
+				time.Sleep(duration)
+				continue
+			} else {
+				msg := fmt.Sprintf("Unable to establish connection to test database: %s", err)
+				t.Skip(msg)
+			}
+		}
+	}
+
+	return db
+}
+
+func getMigrationHelper(t *testing.T) *migrate.Migrate {
+	t.Helper()
+	db := getDatabaseConnection(t)
+
+	driver, err := postgres.WithInstance(db, &postgres.Config{})
+	if err != nil {
+		t.Skip("Unable to initialize database driver for migrations")
+	}
+	m, err := migrate.NewWithDatabaseInstance("file://../migrations", "postgres", driver)
+	if err != nil {
+		t.Skip("Unable to initialize migrations")
+	}
+	return m
+}
+
+func getGormHelper() *gorm.DB {
+	connStr := "host=localhost user=dbadmin dbname=compliance password=secret port=5432 sslmode=disable"
+	gormDB, _ := gorm.Open(gorm_postgres.Open(connStr), &gorm.Config{})
+	return gormDB
+}
+
+func getUUIDString() string {
+	value, _ := uuid.NewRandom()
+	return value.String()
+}


### PR DESCRIPTION
This commit introduces some better organization to the integration tests
by renaming helpers.go to utils.go, moving utility methods out of the
test module (integration_test.go), and creates a new place for
constants.

This commit also removed a direct dependency on github.com/lib/pq in the
integration tests (the tests still execute successfully without this
dependency, so we can clean it up).