### PR TITLE
trivial: Cleanup litter in integration_test.go

### DIFF
--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -170,7 +170,6 @@ func TestInsertMetadataSucceeds(t *testing.T) { // nolint:paralleltest // databa
 
 	a := Metadata{}
 	gormDB.First(&a, "id = ?", id)
-	fmt.Println(a.UpdatedAt)
 
 	e := Metadata{ID: id, CreatedAt: createdAt, UpdatedAt: updatedAt, Version: version, Description: description}
 	assert.Equal(t, e.ID, a.ID, "expected %s got %s", e.ID, a.ID)


### PR DESCRIPTION
This fmt.Println() was left over from introducing metadata testing.