### PR TITLE
Set PGDATA for Kube deployment

### DIFF
--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       - image: postgres:13-alpine
         name: postgres
         env:
+          - name: PGDATA
+            value: /var/lib/postgres/data
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
The postgres container would fail trying to chmod the data directory,
which was the same as the volumemount. Set PGDATA to a `data`
subdirectory to fix this.