### PR TITLE
Add a table for assessments

### DIFF
--- a/migrations/000004_add_assessments_table.down.sql
+++ b/migrations/000004_add_assessments_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS assessments;

--- a/migrations/000004_add_assessments_table.up.sql
+++ b/migrations/000004_add_assessments_table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS assessments (
+  id uuid PRIMARY KEY,
+  name VARCHAR(255),
+  metadata_id UUID,
+  CONSTRAINT fk_assessments_metadata_id FOREIGN KEY (metadata_id) REFERENCES metadata (id)
+);

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -15,6 +15,12 @@ import (
 	"gorm.io/gorm"
 )
 
+type Assessments struct {
+	ID         string
+	Name       string
+	MetadataID string
+}
+
 type Metadata struct {
 	ID          string
 	CreatedAt   time.Time
@@ -95,4 +101,21 @@ func getGormHelper() *gorm.DB {
 func getUUIDString() string {
 	value, _ := uuid.NewRandom()
 	return value.String()
+}
+
+func insertMetadata() (string, error) {
+	gormDB := getGormHelper()
+
+	id := getUUIDString()
+	createdAt := time.Now().UTC().Round(time.Microsecond)
+	updatedAt := time.Now().UTC().Round(time.Microsecond)
+	version := getUUIDString()
+	description := getUUIDString()
+
+	md := Metadata{ID: id, CreatedAt: createdAt, UpdatedAt: updatedAt, Version: version, Description: description}
+	if err := gormDB.Create(&md).Error; err != nil {
+		return "", err
+	}
+
+	return id, nil
 }


### PR DESCRIPTION
The commit adds a new database table for assessments, which are
groupings of results (e.g., scans). This helps organize results based on
assessments of systems or clusters.

This schema was discussed in https://github.com/rhmdnd/compserv/issues/84

Fixes #118