### PR TITLE
trivial: Add missing database cleanup to functional tests

### DIFF
--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -39,12 +39,6 @@ func TestInsertSubjectSucceeds(t *testing.T) { // nolint:paralleltest // databas
 	assert.False(t, subject.ParentID.Valid)
 	assert.Nil(t, err)
 	assert.Nil(t, parentIDValue)
-
-	// Drop the database instead of downgrading since we don't need the
-	// data anyway
-	if err := m.Drop(); err != nil {
-		t.Fatalf("Unable to drop database: %s", err)
-	}
 }
 
 func TestInsertSubjectWithLongNameFails(t *testing.T) { // nolint:paralleltest // database tests should run serially
@@ -62,11 +56,6 @@ func TestInsertSubjectWithLongNameFails(t *testing.T) { // nolint:paralleltest /
 	gormDB := getGormHelper()
 	err := gormDB.Create(&s).Error
 	assert.NotEmpty(t, err, "Shouldn't be able to insert name values longer than 255 characters")
-	// Drop the database instead of downgrading since we don't need the
-	// data anyway
-	if err := m.Drop(); err != nil {
-		t.Fatalf("Unable to drop database: %s", err)
-	}
 }
 
 func TestInsertSubjectWithNonUUIDFails(t *testing.T) { // nolint:paralleltest // database tests should run serially
@@ -83,11 +72,6 @@ func TestInsertSubjectWithNonUUIDFails(t *testing.T) { // nolint:paralleltest //
 	err := gormDB.Create(&s).Error
 	fmt.Print(err)
 	assert.NotEmpty(t, err, "Expect an error when creating IDs of the wrong type.")
-	// Drop the database instead of downgrading since we don't need the
-	// data anyway
-	if err := m.Drop(); err != nil {
-		t.Fatalf("Unable to drop database: %s", err)
-	}
 }
 
 func TestInsertSubjectWithLongTypeFails(t *testing.T) { // nolint:paralleltest // database tests should run serially
@@ -104,11 +88,6 @@ func TestInsertSubjectWithLongTypeFails(t *testing.T) { // nolint:paralleltest /
 	gormDB := getGormHelper()
 	err := gormDB.Create(&s).Error
 	assert.NotEmpty(t, err, "Shouldn't be able to insert type values longer than 50 characters")
-	// Drop the database instead of downgrading since we don't need the
-	// data anyway
-	if err := m.Drop(); err != nil {
-		t.Fatalf("Unable to drop database: %s", err)
-	}
 }
 
 func TestMetadataMigration(t *testing.T) { // nolint:paralleltest // database tests should run serially
@@ -145,10 +124,6 @@ func TestMetadataMigration(t *testing.T) { // nolint:paralleltest // database te
 	}
 	result = gormDB.Migrator().HasTable(tableName)
 	assert.False(t, result, "Table exists after downgrade: %s", tableName)
-
-	if err := m.Drop(); err != nil {
-		t.Fatalf("Unable to drop database: %s", err)
-	}
 }
 
 func TestInsertMetadataSucceeds(t *testing.T) { // nolint:paralleltest // database tests should run serially
@@ -213,12 +188,6 @@ func TestInsertSubjectWithParent(t *testing.T) { // nolint:paralleltest // datab
 	assert.Equal(t, e.Type, a.Type, "expected %s got %s", e.Type, a.Type)
 	assert.True(t, a.ParentID.Valid)
 	assert.Equal(t, e.ParentID.String, a.ParentID.String, "expected %s got %s", e.ParentID.String, a.ParentID.String)
-
-	// Drop the database instead of downgrading since we don't need the
-	// data anyway
-	if err := m.Drop(); err != nil {
-		t.Fatalf("Unable to drop database: %s", err)
-	}
 }
 
 func TestDeleteSubjectWithParent(t *testing.T) { // nolint:paralleltest // database tests should run serially
@@ -271,12 +240,6 @@ func TestDeleteSubjectWithParent(t *testing.T) { // nolint:paralleltest // datab
 	result = gormDB.Find(&subjects)
 	expectedSubjects = int64(0)
 	assert.Equal(t, expectedSubjects, result.RowsAffected, "expected %d got %d", expectedSubjects, result.RowsAffected)
-
-	// Drop the database instead of downgrading since we don't need the
-	// data anyway
-	if err := m.Drop(); err != nil {
-		t.Fatalf("Unable to drop database: %s", err)
-	}
 }
 
 func TestInsertSubjectWithNonExistentParent(t *testing.T) { // nolint:paralleltest // database tests should run serially
@@ -295,12 +258,6 @@ func TestInsertSubjectWithNonExistentParent(t *testing.T) { // nolint:parallelte
 	gormDB := getGormHelper()
 	err := gormDB.Create(&s).Error
 	assert.NotEmpty(t, err, "Shouldn't be able to insert values that violate foreign key constraints")
-
-	// Drop the database instead of downgrading since we don't need the
-	// data anyway
-	if err := m.Drop(); err != nil {
-		t.Fatalf("Unable to drop database: %s", err)
-	}
 }
 
 func TestMigration(t *testing.T) { // nolint:paralleltest // database tests should run serially

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -83,6 +83,13 @@ func getMigrationHelper(t *testing.T) *migrate.Migrate {
 	if err != nil {
 		t.Skipf("Unable to initialize migrations: %s", err)
 	}
+	t.Cleanup(func() {
+		// Drop the database instead of downgrading since we don't need
+		// the data anyway
+		if err = m.Drop(); err != nil {
+			t.Fatalf("Unable to cleanup database: %s", err)
+		}
+	})
 	return m
 }
 


### PR DESCRIPTION
Each functional test should drop the database when it's done. This
ensures a clean database for the next test and prevents tests from
assuming a specific run order.