### PR TITLE
Add metadata_id column to subject table

### DIFF
--- a/migrations/000005_add_subject_metadata_id.down.sql
+++ b/migrations/000005_add_subject_metadata_id.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE subjects DROP CONSTRAINT fk_subjects_metadata_id;
+
+ALTER TABLE subjects DROP COLUMN metadata_id;

--- a/migrations/000005_add_subject_metadata_id.up.sql
+++ b/migrations/000005_add_subject_metadata_id.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE subjects
+Add COLUMN metadata_id UUID;
+
+ALTER TABLE subjects
+ADD CONSTRAINT fk_subjects_metadata_id FOREIGN KEY (metadata_id) REFERENCES metadata (id);

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -30,10 +30,11 @@ type Metadata struct {
 }
 
 type Subject struct {
-	ID       string
-	Name     string
-	Type     string
-	ParentID sql.NullString
+	ID         string
+	Name       string
+	Type       string
+	ParentID   sql.NullString
+	MetadataID sql.NullString
 }
 
 func getDatabaseConnection(t *testing.T) *sql.DB {


### PR DESCRIPTION
The database has a table for metadata, which can be useful for subjects.
Let's add a foreign key to the subject table so we can use metadata with
it.

Fixes #119