### PR TITLE
Add a table for profiles

### DIFF
--- a/migrations/000007_create_profiles_table.down.sql
+++ b/migrations/000007_create_profiles_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS profiles;

--- a/migrations/000007_create_profiles_table.up.sql
+++ b/migrations/000007_create_profiles_table.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS profiles (
+  id uuid PRIMARY KEY,
+  name VARCHAR(255),
+  metadata_id UUID,
+  catalog_id UUID,
+  CONSTRAINT fk_profiles_metadata_id FOREIGN KEY (metadata_id) REFERENCES metadata(id),
+  CONSTRAINT fk_profiles_catalog_id FOREIGN KEY (catalog_id) REFERENCES catalogs(id)
+);
+

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -303,7 +303,7 @@ func TestMigration(t *testing.T) { // nolint:paralleltest // database tests shou
 	// Upgrade the database and make sure all upgrades apply cleanly.
 	err = m.Up()
 	version, dirty, _ = m.Version()
-	expectedVersion = uint(6)
+	expectedVersion = uint(7)
 	assert.Equal(t, expectedVersion, version, "Database version mismatch: want %d but got %d", expectedVersion, version)
 	assert.Equal(t, false, dirty, "Database state mismatch: want %t but got %t", false, dirty)
 	assert.Equal(t, err, nil, "Error upgrading the database: %s", err)


### PR DESCRIPTION
This commit adds a table for profiles so that we can reference controls,
and results to a parent profile.

This table is not designed, at least initially, to store more than just
a profile name and some metadata. This area will be tricky to navigate
moving forward since it would be idea to rely on OSCAL defintions for
profiles, and use OSCAL profiles distributed by standards bodies, and
not maintain them in a service.

This approach is being discussed in issue #84.