### PR TITLE
Add a table for controls

### DIFF
--- a/migrations/000008_create_controls_table.down.sql
+++ b/migrations/000008_create_controls_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS controls;

--- a/migrations/000008_create_controls_table.up.sql
+++ b/migrations/000008_create_controls_table.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS controls (
+  id uuid PRIMARY KEY,
+  name VARCHAR(255),
+  severity VARCHAR(50),
+  profile_id UUID,
+  metadata_id UUID,
+  CONSTRAINT fk_controls_metadata_id FOREIGN KEY (metadata_id) REFERENCES metadata (id),
+  CONSTRAINT fk_controls_profile_id FOREIGN KEY (profile_id) REFERENCES profiles (id)
+);

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -303,7 +303,7 @@ func TestMigration(t *testing.T) { // nolint:paralleltest // database tests shou
 	// Upgrade the database and make sure all upgrades apply cleanly.
 	err = m.Up()
 	version, dirty, _ = m.Version()
-	expectedVersion = uint(7)
+	expectedVersion = uint(8)
 	assert.Equal(t, expectedVersion, version, "Database version mismatch: want %d but got %d", expectedVersion, version)
 	assert.Equal(t, false, dirty, "Database state mismatch: want %t but got %t", false, dirty)
 	assert.Equal(t, err, nil, "Error upgrading the database: %s", err)


### PR DESCRIPTION
This table adds a basic schema for controls, which will be referenced by
results.

Ideally, this control information will supplement information from other
sources like OSCAL catalogs, which should be the preferred source of
information, since it comes from the profile/standard authors.

This schema is being discussed in issue #84.