### PR TITLE
Add a table for catalogs

### DIFF
--- a/migrations/000006_create_catalogs_table.down.sql
+++ b/migrations/000006_create_catalogs_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS catalogs;

--- a/migrations/000006_create_catalogs_table.up.sql
+++ b/migrations/000006_create_catalogs_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS catalogs (
+  id uuid PRIMARY KEY,
+  name VARCHAR(255),
+  metadata_id UUID,
+  content TEXT,
+  CONSTRAINT fk_catalogs_metadata_id FOREIGN KEY (metadata_id) REFERENCES metadata (id)
+);

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -303,7 +303,7 @@ func TestMigration(t *testing.T) { // nolint:paralleltest // database tests shou
 	// Upgrade the database and make sure all upgrades apply cleanly.
 	err = m.Up()
 	version, dirty, _ = m.Version()
-	expectedVersion = uint(5)
+	expectedVersion = uint(6)
 	assert.Equal(t, expectedVersion, version, "Database version mismatch: want %d but got %d", expectedVersion, version)
 	assert.Equal(t, false, dirty, "Database state mismatch: want %t but got %t", false, dirty)
 	assert.Equal(t, err, nil, "Error upgrading the database: %s", err)


### PR DESCRIPTION
Create a table that contains catalogs (ideally written in OSCAL), that
can be parsed to provide information on controls as it was written by
the benchmark authors.

This is being discussed in issue #84.