### PR TITLE
Simplify configuration handling

### DIFF
--- a/cmd/compserv-server.go
+++ b/cmd/compserv-server.go
@@ -18,8 +18,8 @@ func main() {
 	configFile := flag.String("config-file", "config.yaml",
 		"File name of the service config")
 	flag.Parse()
-	c := config.ParseConfig(*configDir, *configFile)
-	connStr := config.GetDatabaseConnectionString(c)
+	v := config.ParseConfig(*configDir, *configFile)
+	connStr := config.GetDatabaseConnectionString(v)
 	db, err := gorm.Open(postgres.Open(connStr), &gorm.Config{})
 	if err != nil {
 		log.Fatalf("Failed to connect to database: %s", err)
@@ -27,7 +27,7 @@ func main() {
 
 	log.Printf("Connected to database: %v", db)
 
-	appStr := c["app_host"] + ":" + c["app_port"]
+	appStr := v.GetString("app.host") + ":" + v.GetString("app.port")
 	lis, err := net.Listen("tcp", appStr)
 	if err != nil {
 		log.Fatalf("Failed to listen to %s: %v", appStr, err)


### PR DESCRIPTION
We use viper to parse configuration. Previously, we would use the library to set defaults, parse configuration, and lookup values. Then, we'd put that into a map for other parts of the compliance service to use.

This just introduced a middle layer in configuration handling that wasn't necessary. Instead, let's just pass back an instance of the viper configuration handler and let parts of the application call the values they need out of it using `viper.GetString()`.

This is less error prone since it doesn't require maintainers to keep a extra mental mapping between viper configuration and an internal map.