### PR TITLE
Improve database connection logging

### DIFF
--- a/cmd/compserv-server.go
+++ b/cmd/compserv-server.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatalf("Failed to connect to database: %s", err)
 	}
 
-	log.Printf("Connected to database: %v", db)
+	log.Printf("Connected to database: %v", v.GetString("database.host"))
 
 	appStr := v.GetString("app.host") + ":" + v.GetString("app.port")
 	lis, err := net.Listen("tcp", appStr)


### PR DESCRIPTION
Previously, we'd log information about the database instance when connecting to it (e.g., memory address), but this information didn't really include anything useful from an operations standpoint.

Let's log the actual database endpoint instead, so it's more clear what the service is actually connecting to.