### PR TITLE
Add a Makefile target for cleaning tools and builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ $(TOOLS_DIR):
 build: $(BUILDS_DIR)
 	go build -o $(BUILDS_DIR) cmd/compserv-server.go
 
+.PHONY: clean
+clean:
+	rm -f $(BUILDS_DIR)/*
+	rm -f $(TOOLS_DIR)/*
+
 .PHONY: grpc
 grpc: $(TOOLS_DIR)/protoc
 	$(PROTOC) --go_out=. --go-grpc_out=. --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative pkg/api/compserv.proto


### PR DESCRIPTION
We download development dependencies in tools/ and put builds in
builds/. Let's add a makefile target to clean up these directories since
we also have automation for build and downloading fresh copies.
