### PR TITLE
Explicitly ignore builds and tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-# Ignore builds and tools
-builds/
-tools/
+# Ignore builds and tools. Be explicit in what we ignore from our own
+# repository. Since we use vendored dependencies, it's possible that `tools/`
+# would ignore tools/ directories in dependencies, causing CI issues that are
+# hard to debug locally.
+builds/compserv-server
+tools/golangci-lint
+tools/kubectl
+tools/migrate
+tools/protoc
 
 # Ignore potential configs
 configs/config.yaml


### PR DESCRIPTION
Git ignore is greedy, meaning `tools/` will match any subdirectory in
the repository, not just the `tools/` we use at the root. This is a
problem if we have a lot of dependencies that might have a directory in
their package called `tools/`, or anything else we ignore.

Let's be explicit in ignoring our own tools and builds so that we don't
accidentally ignore something a dependency needs.
