### PR TITLE
Add support for deploying ComplianceAsCode/compliance-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,12 @@ deploy: $(TOOLS_DIR)/kubectl
 undeploy: $(TOOLS_DIR)/kubectl
 	$(KUBECTL) delete -k kustomize
 
+# Basic installation of ComplianceAsCode/compliance-operator so we can use the
+# same cluster for generating results for the compserv.
+.PHONY: deploy-co
+deploy-co: $(TOOLS_DIR)/kubectl
+	$(KUBECTL) apply -k kustomize/compliance-operator
+
 $(TOOLS_DIR)/kubectl: $(TOOLS_DIR)
 # Check if tools/kubectl exists - if it does then the default value provided
 # above will work.

--- a/kustomize/compliance-operator/kustomization.yaml
+++ b/kustomize/compliance-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+namespace: openshift-compliance
+resources:
+  - namespace.yaml
+  - operator-group.yaml
+  - subscription.yaml

--- a/kustomize/compliance-operator/namespace.yaml
+++ b/kustomize/compliance-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-compliance

--- a/kustomize/compliance-operator/operator-group.yaml
+++ b/kustomize/compliance-operator/operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: compliance-operator
+  namespace: openshift-compliance
+spec:
+  targetNamespaces:
+  - openshift-compliance

--- a/kustomize/compliance-operator/subscription.yaml
+++ b/kustomize/compliance-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: "release-0.1"
+  installPlanApproval: Automatic
+  name: compliance-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Since the whole purpose of compserv is to parse compliance results, we
can host the compliance-operator on the same cluster to generate
results.

This commit adds a new kustomize directory for installing the
compliance-operator on the same cluster that the compliance service is
running.
