### PR TITLE
Fix default values in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ MIGRATE?=
 KUBECTL = ./$(TOOLS_DIR)/kubectl
 PROTOC = ./$(TOOLS_DIR)/protoc
 
-IMAGE_REPO := quay.io/compliance-service/compserv
-TAG := latest
+IMAGE_REPO ?= quay.io/compliance-service/compserv
+TAG ?= latest
 
 .PHONY: $(BUILDS_DIR)
 $(BUILDS_DIR):


### PR DESCRIPTION
Use ?= instead of := for default values. This makes it so they can be
overridden.
